### PR TITLE
Fail gracefully on top-level char data

### DIFF
--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"strings"
 )
@@ -60,6 +61,10 @@ func ReadXML(reader xml.TokenReader) ([]Element, error) {
 		case xml.CharData:
 			s := string(token)
 			if len(strings.TrimSpace(s)) != 0 {
+				if depth == 0 {
+					return nil, fmt.Errorf("unexpected top-level char data `%s`", s)
+				}
+
 				parent := stack[len(stack)-1]
 				parent.ContainsCharData = true
 

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -23,6 +23,20 @@ func TestEmptyXML(t *testing.T) {
 	}
 }
 
+func TestTopLevelCharData(t *testing.T) {
+	doc := `test`
+
+	ee, err := read(doc)
+	if ee != nil {
+		t.Errorf("expected error, got %s", str(ee))
+	}
+
+	expected := "unexpected top-level char data `test`"
+	if err.Error() != expected {
+		t.Errorf("got %s, want %s", err.Error(), expected)
+	}
+}
+
 func TestElementContainingCommentNoChildren(t *testing.T) {
 	doc := `
 <shape


### PR DESCRIPTION
instead of panicking. Fixes #3 